### PR TITLE
RenovateのPRにラベル付与&メジャーバージョン以外のautomergeを設定

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,14 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "labels": [
+    "dependencies"
+  ],
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
Renovateに以下設定を追加しました

- Renovateのラベルとして`dependencies`を追加
- メジャーバージョンアップ以外のautomerge設定