### PR TITLE
遺物/オーナメントのメインオプションごとの利用状況を整理する

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,9 +8,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { getArtifact } from '@/api/getArtifact';
-import { getBodyData, getLegData } from '@/api/getData';
-import { ArtifactUsage } from './interfaces/Artifact';
+import { type ArtifactUsage, getArtifactUsage } from '@/app/features/usageArtifact/model';
 import { getArtifactList } from '@/app/entities/artifact/api';
 import { getOrnamentList } from '@/app/entities/ornament/api';
 
@@ -23,13 +21,13 @@ const Section: FC<{ title: string; data: ArtifactUsage[] }> = ({ title, data }) 
 
 const App: FC = () => {
   const [filterArtifactId, setFilterArtifactId] = useState<string>('');
-  // TODO: プルダウンリストの改善は後続Issueで実施予定
-  const artifactTypeList = [...getArtifactList(), ...getOrnamentList()];
 
+  const artifactTypeList = [...getArtifactList(), ...getOrnamentList()];
   const artifact = artifactTypeList.find((artifactType) => artifactType.id === filterArtifactId);
-  const data = getArtifact(filterArtifactId);
-  const bodyData = getBodyData(data);
-  const legData = getLegData(data);
+
+  const artifactUsage = getArtifactUsage(filterArtifactId);
+  const bodyData = artifactUsage.body;
+  const footData = artifactUsage.foot;
 
   return (
     <Fragment>
@@ -40,7 +38,7 @@ const App: FC = () => {
         <p className='text-2xl'>{artifact?.name || '遺物を選択してください'}</p>
         <div className='py-3'>
           <Section title="胴体" data={bodyData} />
-          <Section title="脚部" data={legData} />
+          <Section title="脚部" data={footData} />
         </div>
       </div>
       <div className='fixed bottom-0 bg-slate-200 h-18 w-full px-6 py-4'>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,8 @@ import {
 import { type ArtifactUsage, getArtifactUsage } from '@/app/features/usageArtifact/model';
 import { getArtifactList } from '@/app/entities/artifact/api';
 import { getOrnamentList } from '@/app/entities/ornament/api';
+import { getBuildsetList } from '@/app/entities/charactor/model';
+import { getCharactorList } from '@/app/entities/charactor/api';
 
 const Section: FC<{ title: string; data: ArtifactUsage[] }> = ({ title, data }) => (
   <div className='mb-8'>
@@ -20,12 +22,12 @@ const Section: FC<{ title: string; data: ArtifactUsage[] }> = ({ title, data }) 
 );
 
 const App: FC = () => {
-  const [filterArtifactId, setFilterArtifactId] = useState<string>('');
+  const [filterArtifactId, setFilterArtifactId] = useState<string>(getArtifactList()[0].id);
 
   const artifactTypeList = [...getArtifactList(), ...getOrnamentList()];
   const artifact = artifactTypeList.find((artifactType) => artifactType.id === filterArtifactId);
 
-  const artifactUsage = getArtifactUsage(filterArtifactId);
+  const artifactUsage = getArtifactUsage(filterArtifactId, getBuildsetList(getCharactorList()));
   const bodyData = artifactUsage.body;
   const footData = artifactUsage.foot;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,15 +8,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { type ArtifactUsage, getArtifactUsage } from '@/app/features/usageArtifact/model';
+import { isArtifactId } from '@/app/entities/artifact/model';
 import { getArtifactList } from '@/app/entities/artifact/api';
 import { getOrnamentList } from '@/app/entities/ornament/api';
 import { getBuildsetList } from '@/app/entities/charactor/model';
 import { getCharactorList } from '@/app/entities/charactor/api';
+import { type ArtifactUsage, getArtifactUsage } from '@/app/features/usageArtifact/model';
 
 const Section: FC<{ title: string; data: ArtifactUsage[] }> = ({ title, data }) => (
-  <div className='mb-8'>
-    <p className='text-xl'>{title}</p>
+  <div className='mb-4'>
+    <p className='text-lg'>{title}</p>
     <Table data={data} />
   </div>
 );
@@ -30,17 +31,28 @@ const App: FC = () => {
   const artifactUsage = getArtifactUsage(filterArtifactId, getBuildsetList(getCharactorList()));
   const bodyData = artifactUsage.body;
   const footData = artifactUsage.foot;
+  const sphereData = artifactUsage.sphere;
+  const ropeData = artifactUsage.rope;
 
   return (
     <Fragment>
-      <div className='bg-slate-200 h-16 w-full shadow-md px-6 py-4'>
-        <p className='text-2xl'>HSR-Artifacts</p>
+      <div className='bg-slate-200 h-8 w-full shadow-md px-6 py-1'>
+        <p className='text-lg'>HSR-Artifacts</p>
       </div>
-      <div className='px-6 py-4 w-full'>
-        <p className='text-2xl'>{artifact?.name || '遺物を選択してください'}</p>
-        <div className='py-3'>
-          <Section title="胴体" data={bodyData} />
-          <Section title="脚部" data={footData} />
+      <div className='px-6 py-2 w-full'>
+        <p className='text-lg'>{artifact?.name || '遺物を選択してください'}</p>
+        <div className='py-2'>
+          {isArtifactId(filterArtifactId) ?
+          <>
+            <Section title="胴体" data={bodyData} />
+            <Section title="脚部" data={footData} />
+          </>
+          :
+          <>
+            <Section title="オーブ" data={sphereData} />
+            <Section title="縄" data={ropeData} />
+          </>
+          }
         </div>
       </div>
       <div className='fixed bottom-0 bg-slate-200 h-18 w-full px-6 py-4'>

--- a/src/app/entities/artifact/model/index.ts
+++ b/src/app/entities/artifact/model/index.ts
@@ -1,1 +1,2 @@
 export * from './interfaces';
+export * from './isArtifactId';

--- a/src/app/entities/artifact/model/isArtifactId.ts
+++ b/src/app/entities/artifact/model/isArtifactId.ts
@@ -1,0 +1,5 @@
+const isArtifactId = (id: string): boolean => {
+  return id.startsWith("0");
+}
+
+export { isArtifactId };

--- a/src/app/entities/charactor/api/getCharactorList.ts
+++ b/src/app/entities/charactor/api/getCharactorList.ts
@@ -1,7 +1,7 @@
 import { charactorDataset } from "@/app/entities/charactor/config";
 
-const getCharactor = () => {
+const getCharactorList = () => {
   return charactorDataset;
 }
 
-export { getCharactor };
+export { getCharactorList };

--- a/src/app/entities/charactor/api/index.ts
+++ b/src/app/entities/charactor/api/index.ts
@@ -1,1 +1,1 @@
-export * from './getCharactor';
+export * from './getCharactorList';

--- a/src/app/entities/charactor/config/charactorData/2001_shujinkoKaimetsu.ts
+++ b/src/app/entities/charactor/config/charactorData/2001_shujinkoKaimetsu.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const shujinkoKaimetsu: Charactor = {
   id: '2001',
   name: '主人公(壊滅)',
-  buldsets: [
+  buildsets: [
     {
       id: '2001-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2002_shujinkoSongo.ts
+++ b/src/app/entities/charactor/config/charactorData/2002_shujinkoSongo.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const shujinkoSongo: Charactor = {
   id: '2002',
   name: '主人公(存護)',
-  buldsets: [
+  buildsets: [
     {
       id: '2002-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2003_himeko.ts
+++ b/src/app/entities/charactor/config/charactorData/2003_himeko.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const himeko: Charactor = {
   id: '2003',
   name: '姫子',
-  buldsets: [
+  buildsets: [
     {
       id: '2003-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2004_veruto.ts
+++ b/src/app/entities/charactor/config/charactorData/2004_veruto.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const veruto: Charactor = {
   id: '2004',
   name: 'ヴェルト',
-  buldsets: [
+  buildsets: [
     {
       id: '2004-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2005_buronya.ts
+++ b/src/app/entities/charactor/config/charactorData/2005_buronya.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const buronya: Charactor = {
   id: '2005',
   name: 'ブローニャ',
-  buldsets: [
+  buildsets: [
     {
       id: '2005-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2006_jepado.ts
+++ b/src/app/entities/charactor/config/charactorData/2006_jepado.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const jepado: Charactor = {
   id: '2006',
   name: 'ジェパード',
-  buldsets: [
+  buildsets: [
     {
       id: '2006-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2007_kurara.ts
+++ b/src/app/entities/charactor/config/charactorData/2007_kurara.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const kurara: Charactor = {
   id: '2007',
   name: 'クラーラ',
-  buldsets: [
+  buildsets: [
     {
       id: '2007-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2008_genkyo.ts
+++ b/src/app/entities/charactor/config/charactorData/2008_genkyo.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const genkyo: Charactor = {
   id: '2008',
   name: '彦卿',
-  buldsets: [
+  buildsets: [
     {
       id: '2008-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2009_byakuro.ts
+++ b/src/app/entities/charactor/config/charactorData/2009_byakuro.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const byakuro: Charactor = {
   id: '2009',
   name: '白露',
-  buldsets: [
+  buildsets: [
     {
       id: '2009-1',
       artifacts: {

--- a/src/app/entities/charactor/config/charactorData/2010_zere.ts
+++ b/src/app/entities/charactor/config/charactorData/2010_zere.ts
@@ -3,7 +3,7 @@ import type { Charactor } from "@/app/entities/charactor/model";
 export const zere: Charactor = {
   id: '2010',
   name: 'ゼーレ',
-  buldsets: [
+  buildsets: [
     {
       id: '2010-1',
       artifacts: {

--- a/src/app/entities/charactor/model/getBuildsetList.ts
+++ b/src/app/entities/charactor/model/getBuildsetList.ts
@@ -1,0 +1,6 @@
+import type { Buildset, Charactor } from "@/app/entities/charactor/model";
+
+const getBuildsetList = (charactorList: Charactor[]): Buildset[] => 
+  charactorList.flatMap((charactor) => charactor.buldsets);
+
+export { getBuildsetList };

--- a/src/app/entities/charactor/model/getBuildsetList.ts
+++ b/src/app/entities/charactor/model/getBuildsetList.ts
@@ -1,6 +1,5 @@
 import type { Buildset, Charactor } from "@/app/entities/charactor/model";
 
 const getBuildsetList = (charactorList: Charactor[]): Buildset[] => 
-  charactorList.flatMap((charactor) => charactor.buldsets);
-
+  charactorList.flatMap((charactor) => charactor.buildsets);
 export { getBuildsetList };

--- a/src/app/entities/charactor/model/index.ts
+++ b/src/app/entities/charactor/model/index.ts
@@ -1,1 +1,2 @@
 export * from './interfaces';
+export * from './getBuildsetList';

--- a/src/app/entities/charactor/model/interfaces.ts
+++ b/src/app/entities/charactor/model/interfaces.ts
@@ -28,4 +28,4 @@ type Charactor = {
   buldsets : Buildset[];
 };
 
-export type { Buildset, Charactor, BodyOption, FootOption };
+export type { Buildset, Charactor, BodyOption, FootOption, SphereOption, RopeOption };

--- a/src/app/entities/charactor/model/interfaces.ts
+++ b/src/app/entities/charactor/model/interfaces.ts
@@ -25,7 +25,7 @@ type Charactor = {
   name : string;
   type?: string;
   destiny?: string;
-  buldsets : Buildset[];
+  buildsets : Buildset[];
 };
 
 export type { Buildset, Charactor, BodyOption, FootOption, SphereOption, RopeOption };

--- a/src/app/entities/charactor/model/interfaces.ts
+++ b/src/app/entities/charactor/model/interfaces.ts
@@ -28,4 +28,4 @@ type Charactor = {
   buldsets : Buildset[];
 };
 
-export type { Buildset, Charactor };
+export type { Buildset, Charactor, BodyOption, FootOption };

--- a/src/app/entities/ornament/model/index.ts
+++ b/src/app/entities/ornament/model/index.ts
@@ -1,1 +1,2 @@
 export * from './interfaces';
+export * from './isOrnamentId';

--- a/src/app/entities/ornament/model/isOrnamentId.ts
+++ b/src/app/entities/ornament/model/isOrnamentId.ts
@@ -1,0 +1,5 @@
+const isOrnamentId = (id: string): boolean => {
+  return id.startsWith("1");
+}
+
+export { isOrnamentId };

--- a/src/app/features/usageArtifact/model/getArtifactUsage.ts
+++ b/src/app/features/usageArtifact/model/getArtifactUsage.ts
@@ -1,27 +1,23 @@
 import { isArtifactId } from '@/app/entities/artifact/model';
-import type { Buildset } from '@/app/entities/charactor/model';
+import type { Buildset, BodyOption, FootOption, SphereOption, RopeOption } from '@/app/entities/charactor/model';
 import { isOrnamentId } from '@/app/entities/ornament/model';
 import type {
   ArtifactUsage,
   ArtifactUsageResult,
-  BodyOption,
-  FootOption,
-  RopeOption, // Placeholder
-  SphereOption, // Placeholder
 } from './interfaces';
 import {
   BODY_OPTIONS,
   FOOT_OPTIONS,
-  ROPE_OPTIONS, // Placeholder
-  SPHERE_OPTIONS, // Placeholder
+  ROPE_OPTIONS,
+  SPHERE_OPTIONS,
 } from './interfaces';
 
 /**
- * Calculates the usage statistics for a given list of options based on buildsets.
- * @param buildsets - The list of character buildsets.
- * @param optionsList - The list of possible main options for the artifact/ornament piece.
- * @param getOptionsFromBuildset - A function that extracts the relevant options array from a single buildset.
- * @returns An array of ArtifactUsage objects.
+ * ビルドセットに基づいて、指定されたオプションリストの使用統計を計算します。
+ * @param buildsets - キャラクタービルドセットのリスト。
+ * @param optionsList - 遺物/オーナメントの部位のメインオプションのリスト。
+ * @param getOptionsFromBuildset - 単一のビルドセットから関連するオプション配列を抽出する関数。
+ * @returns ArtifactUsage オブジェクトの配列。
  */
 const calculateUsageData = <T extends string>(
   buildsets: Buildset[],
@@ -37,11 +33,11 @@ const calculateUsageData = <T extends string>(
 };
 
 /**
- * Calculates the usage statistics for a specific artifact or ornament set.
- * @param artifactOrOrnamentId - The ID of the artifact or ornament set.
- * @param allBuildsets - A list of all character buildsets.
- * @returns An ArtifactUsageResult object containing usage data for each piece.
- * @throws Error if the provided ID is not a valid artifact or ornament ID.
+ * 特定の遺物またはオーナメントセットの使用統計を計算します。
+ * @param artifactOrOrnamentId - 遺物またはオーナメントセットのID。
+ * @param allBuildsets - すべてのキャラクタービルドセットのリスト。
+ * @returns 各部位の使用データを含む ArtifactUsageResult オブジェクト。
+ * @throws 提供されたIDが有効な遺物またはオーナメントIDでない場合にエラーをスローします。
  */
 const getArtifactUsage = (
   artifactOrOrnamentId: string,
@@ -75,7 +71,7 @@ const getArtifactUsage = (
       (buildset) => buildset.artifacts.footOptions
     );
 
-    // Sphere and Rope are not applicable to regular artifacts
+    // オーブと縄は遺物には適用されません
     return {
       ...initialResult,
       body: bodyUsageData,
@@ -88,19 +84,18 @@ const getArtifactUsage = (
       buildset.ornaments.ornamentIds.includes(artifactOrOrnamentId)
     );
 
-    // TODO: Replace placeholders once SphereOption/RopeOption and their extraction logic are defined
     const sphereUsageData = calculateUsageData<SphereOption>(
       relevantBuildsets,
-      SPHERE_OPTIONS, // Placeholder options
-      (buildset) => buildset.ornaments.sphereOptions // Placeholder accessor
+      SPHERE_OPTIONS,
+      (buildset) => buildset.ornaments.sphereOptions
     );
     const ropeUsageData = calculateUsageData<RopeOption>(
       relevantBuildsets,
-      ROPE_OPTIONS, // Placeholder options
-      (buildset) => buildset.ornaments.ropeOptions // Placeholder accessor
+      ROPE_OPTIONS,
+      (buildset) => buildset.ornaments.ropeOptions
     );
 
-    // Body and Foot are not applicable to ornaments
+    // 胴と脚はオーナメントには適用されません
     return {
       ...initialResult,
       sphere: sphereUsageData,
@@ -108,8 +103,6 @@ const getArtifactUsage = (
     };
   }
 
-  // This line should theoretically be unreachable due to the initial check,
-  // but included for exhaustive type checking and safety.
   return initialResult;
 };
 

--- a/src/app/features/usageArtifact/model/getArtifactUsage.ts
+++ b/src/app/features/usageArtifact/model/getArtifactUsage.ts
@@ -1,80 +1,116 @@
-import { isArtifactId } from "@/app/entities/artifact/model";
-import { getCharactorList } from "@/app/entities/charactor/api";
-import { Buildset, FootOption, getBuildsetList, type BodyOption } from "@/app/entities/charactor/model";
-import { isOrnamentId } from "@/app/entities/ornament/model";
-import type { ArtifactUsage } from "@/interfaces/Artifact";
+import { isArtifactId } from '@/app/entities/artifact/model';
+import type { Buildset } from '@/app/entities/charactor/model';
+import { isOrnamentId } from '@/app/entities/ornament/model';
+import type {
+  ArtifactUsage,
+  ArtifactUsageResult,
+  BodyOption,
+  FootOption,
+  RopeOption, // Placeholder
+  SphereOption, // Placeholder
+} from './interfaces';
+import {
+  BODY_OPTIONS,
+  FOOT_OPTIONS,
+  ROPE_OPTIONS, // Placeholder
+  SPHERE_OPTIONS, // Placeholder
+} from './interfaces';
 
-const getBodyData = (artifacts: Buildset[]):ArtifactUsage[] => {
-  const bodyArtifactMainOptions: BodyOption[] = [
-    '会心率',
-    '会心ダメージ',
-    'HP%',
-    '攻撃力%',
-    '防御力%',
-    '治癒量',
-    '効果命中'
-  ] 
+/**
+ * Calculates the usage statistics for a given list of options based on buildsets.
+ * @param buildsets - The list of character buildsets.
+ * @param optionsList - The list of possible main options for the artifact/ornament piece.
+ * @param getOptionsFromBuildset - A function that extracts the relevant options array from a single buildset.
+ * @returns An array of ArtifactUsage objects.
+ */
+const calculateUsageData = <T extends string>(
+  buildsets: Buildset[],
+  optionsList: T[],
+  getOptionsFromBuildset: (buildset: Buildset) => T[]
+): ArtifactUsage[] => {
+  return optionsList.map<ArtifactUsage>((option) => ({
+    mainOption: option,
+    usage: buildsets.filter((buildset) =>
+      getOptionsFromBuildset(buildset).includes(option)
+    ).length,
+  }));
+};
 
-  return bodyArtifactMainOptions.map<ArtifactUsage>((option) => (
-    {
-      mainOption: option,
-      usage: artifacts.filter((data) => data.artifacts.bodyOptions.includes(option)).length,
-    }
-  ));
-}
-
-const getFootData = (artifacts: Buildset[]):ArtifactUsage[] => {
-  const footArtifactMainOptions : FootOption[]  = [
-    'HP%',
-    '攻撃力%',
-    '防御力%',
-    '速度'
-  ] 
-
-
-  return footArtifactMainOptions.map<ArtifactUsage>((option) => (
-    {
-      mainOption: option,
-      usage: artifacts.filter((data) => data.artifacts.footOptions.includes(option)).length,
-    }
-  ));
-}
-
-const getArtifactUsage = (artifactId: string) => {
-  const artifactUsage = {
-    artifactId: '',
+/**
+ * Calculates the usage statistics for a specific artifact or ornament set.
+ * @param artifactOrOrnamentId - The ID of the artifact or ornament set.
+ * @param allBuildsets - A list of all character buildsets.
+ * @returns An ArtifactUsageResult object containing usage data for each piece.
+ * @throws Error if the provided ID is not a valid artifact or ornament ID.
+ */
+const getArtifactUsage = (
+  artifactOrOrnamentId: string,
+  allBuildsets: Buildset[]
+): ArtifactUsageResult => {
+  const initialResult: ArtifactUsageResult = {
+    artifactId: artifactOrOrnamentId,
     body: [],
     foot: [],
     sphere: [],
-    rope: []
-  }
-  if (!isArtifactId(artifactId) && !isOrnamentId(artifactId)) {
-    console.error("Invalid artifactId or ornamentId");
-    return artifactUsage;
+    rope: [],
+  };
+
+  if (!isArtifactId(artifactOrOrnamentId) && !isOrnamentId(artifactOrOrnamentId)) {
+    throw new Error(`Invalid artifactId or ornamentId: ${artifactOrOrnamentId}`);
   }
 
-  const buildsets = getBuildsetList(getCharactorList());
+  if (isArtifactId(artifactOrOrnamentId)) {
+    const relevantBuildsets = allBuildsets.filter((buildset) =>
+      buildset.artifacts.artifactIds.includes(artifactOrOrnamentId)
+    );
 
-  if (isArtifactId(artifactId)) {
-    const artifactBuildSet =  buildsets.filter((buildset) => buildset.artifacts.artifactIds.includes(artifactId));
-    const bodyUsageData = getBodyData(artifactBuildSet);
-    const footUsageData = getFootData(artifactBuildSet);
-    console.log(footUsageData);
-    console.log(bodyUsageData);
+    const bodyUsageData = calculateUsageData<BodyOption>(
+      relevantBuildsets,
+      BODY_OPTIONS,
+      (buildset) => buildset.artifacts.bodyOptions
+    );
+    const footUsageData = calculateUsageData<FootOption>(
+      relevantBuildsets,
+      FOOT_OPTIONS,
+      (buildset) => buildset.artifacts.footOptions
+    );
+
+    // Sphere and Rope are not applicable to regular artifacts
     return {
-      ...artifactUsage,
-      artifactId: artifactId,
+      ...initialResult,
       body: bodyUsageData,
-      foot: footUsageData
+      foot: footUsageData,
     };
   }
 
-  if (isOrnamentId(artifactId)) {
-    // return buildsets.filter((buildset) => buildset.ornaments.ornamentIds.includes(artifactId));
-    return artifactUsage;
+  if (isOrnamentId(artifactOrOrnamentId)) {
+    const relevantBuildsets = allBuildsets.filter((buildset) =>
+      buildset.ornaments.ornamentIds.includes(artifactOrOrnamentId)
+    );
+
+    // TODO: Replace placeholders once SphereOption/RopeOption and their extraction logic are defined
+    const sphereUsageData = calculateUsageData<SphereOption>(
+      relevantBuildsets,
+      SPHERE_OPTIONS, // Placeholder options
+      (buildset) => buildset.ornaments.sphereOptions // Placeholder accessor
+    );
+    const ropeUsageData = calculateUsageData<RopeOption>(
+      relevantBuildsets,
+      ROPE_OPTIONS, // Placeholder options
+      (buildset) => buildset.ornaments.ropeOptions // Placeholder accessor
+    );
+
+    // Body and Foot are not applicable to ornaments
+    return {
+      ...initialResult,
+      sphere: sphereUsageData,
+      rope: ropeUsageData,
+    };
   }
 
-  return artifactUsage;
-}
+  // This line should theoretically be unreachable due to the initial check,
+  // but included for exhaustive type checking and safety.
+  return initialResult;
+};
 
 export { getArtifactUsage };

--- a/src/app/features/usageArtifact/model/getArtifactUsage.ts
+++ b/src/app/features/usageArtifact/model/getArtifactUsage.ts
@@ -1,0 +1,80 @@
+import { isArtifactId } from "@/app/entities/artifact/model";
+import { getCharactorList } from "@/app/entities/charactor/api";
+import { Buildset, FootOption, getBuildsetList, type BodyOption } from "@/app/entities/charactor/model";
+import { isOrnamentId } from "@/app/entities/ornament/model";
+import type { ArtifactUsage } from "@/interfaces/Artifact";
+
+const getBodyData = (artifacts: Buildset[]):ArtifactUsage[] => {
+  const bodyArtifactMainOptions: BodyOption[] = [
+    '会心率',
+    '会心ダメージ',
+    'HP%',
+    '攻撃力%',
+    '防御力%',
+    '治癒量',
+    '効果命中'
+  ] 
+
+  return bodyArtifactMainOptions.map<ArtifactUsage>((option) => (
+    {
+      mainOption: option,
+      usage: artifacts.filter((data) => data.artifacts.bodyOptions.includes(option)).length,
+    }
+  ));
+}
+
+const getFootData = (artifacts: Buildset[]):ArtifactUsage[] => {
+  const footArtifactMainOptions : FootOption[]  = [
+    'HP%',
+    '攻撃力%',
+    '防御力%',
+    '速度'
+  ] 
+
+
+  return footArtifactMainOptions.map<ArtifactUsage>((option) => (
+    {
+      mainOption: option,
+      usage: artifacts.filter((data) => data.artifacts.footOptions.includes(option)).length,
+    }
+  ));
+}
+
+const getArtifactUsage = (artifactId: string) => {
+  const artifactUsage = {
+    artifactId: '',
+    body: [],
+    foot: [],
+    sphere: [],
+    rope: []
+  }
+  if (!isArtifactId(artifactId) && !isOrnamentId(artifactId)) {
+    console.error("Invalid artifactId or ornamentId");
+    return artifactUsage;
+  }
+
+  const buildsets = getBuildsetList(getCharactorList());
+
+  if (isArtifactId(artifactId)) {
+    const artifactBuildSet =  buildsets.filter((buildset) => buildset.artifacts.artifactIds.includes(artifactId));
+    const bodyUsageData = getBodyData(artifactBuildSet);
+    const footUsageData = getFootData(artifactBuildSet);
+    console.log(footUsageData);
+    console.log(bodyUsageData);
+    return {
+      ...artifactUsage,
+      artifactId: artifactId,
+      body: bodyUsageData,
+      foot: footUsageData
+    };
+  }
+
+  if (isOrnamentId(artifactId)) {
+    // return buildsets.filter((buildset) => buildset.ornaments.ornamentIds.includes(artifactId));
+    return artifactUsage;
+  }
+
+  return artifactUsage;
+}
+
+export { getArtifactUsage };

--- a/src/app/features/usageArtifact/model/index.ts
+++ b/src/app/features/usageArtifact/model/index.ts
@@ -1,0 +1,2 @@
+export * from './interfaces';
+export * from './getArtifactUsage';

--- a/src/app/features/usageArtifact/model/interfaces.ts
+++ b/src/app/features/usageArtifact/model/interfaces.ts
@@ -1,4 +1,44 @@
 export type ArtifactUsage = {
-  mainOption: string,
-  usage: number,
+  mainOption: string;
+  usage: number;
+};
+
+export type BodyOption =
+  | '会心率'
+  | '会心ダメージ'
+  | 'HP%'
+  | '攻撃力%'
+  | '防御力%'
+  | '治癒量'
+  | '効果命中';
+
+export type FootOption = 'HP%' | '攻撃力%' | '防御力%' | '速度';
+
+// TODO: Define SphereOption and RopeOption based on actual game data
+export type SphereOption = string; // Placeholder
+export type RopeOption = string;   // Placeholder
+
+export const BODY_OPTIONS: BodyOption[] = [
+  '会心率',
+  '会心ダメージ',
+  'HP%',
+  '攻撃力%',
+  '防御力%',
+  '治癒量',
+  '効果命中',
+];
+
+export const FOOT_OPTIONS: FootOption[] = ['HP%', '攻撃力%', '防御力%', '速度'];
+
+// TODO: Define SPHERE_OPTIONS and ROPE_OPTIONS based on actual game data
+export const SPHERE_OPTIONS: SphereOption[] = []; // Placeholder
+export const ROPE_OPTIONS: RopeOption[] = [];   // Placeholder
+
+
+export type ArtifactUsageResult = {
+  artifactId: string;
+  body: ArtifactUsage[];
+  foot: ArtifactUsage[];
+  sphere: ArtifactUsage[];
+  rope: ArtifactUsage[];
 };

--- a/src/app/features/usageArtifact/model/interfaces.ts
+++ b/src/app/features/usageArtifact/model/interfaces.ts
@@ -1,0 +1,4 @@
+export type ArtifactUsage = {
+  mainOption: string,
+  usage: number,
+};

--- a/src/app/features/usageArtifact/model/interfaces.ts
+++ b/src/app/features/usageArtifact/model/interfaces.ts
@@ -1,22 +1,9 @@
+import type { BodyOption, FootOption, SphereOption, RopeOption } from "@/app/entities/charactor/model";
+
 export type ArtifactUsage = {
   mainOption: string;
   usage: number;
 };
-
-export type BodyOption =
-  | '会心率'
-  | '会心ダメージ'
-  | 'HP%'
-  | '攻撃力%'
-  | '防御力%'
-  | '治癒量'
-  | '効果命中';
-
-export type FootOption = 'HP%' | '攻撃力%' | '防御力%' | '速度';
-
-// TODO: Define SphereOption and RopeOption based on actual game data
-export type SphereOption = string; // Placeholder
-export type RopeOption = string;   // Placeholder
 
 export const BODY_OPTIONS: BodyOption[] = [
   '会心率',
@@ -30,9 +17,25 @@ export const BODY_OPTIONS: BodyOption[] = [
 
 export const FOOT_OPTIONS: FootOption[] = ['HP%', '攻撃力%', '防御力%', '速度'];
 
-// TODO: Define SPHERE_OPTIONS and ROPE_OPTIONS based on actual game data
-export const SPHERE_OPTIONS: SphereOption[] = []; // Placeholder
-export const ROPE_OPTIONS: RopeOption[] = [];   // Placeholder
+export const SPHERE_OPTIONS: SphereOption[] = [
+  'HP%',
+  '攻撃力%',
+  '防御力%',
+  '物理属性与ダメージ',
+  '炎属性与ダメージ',
+  '氷属性与ダメージ',
+  '雷属性与ダメージ',
+  '風属性与ダメージ',
+  '量子属性与ダメージ',
+  '虚数属性与ダメージ',
+];
+export const ROPE_OPTIONS: RopeOption[] = [
+  'HP%',
+  '攻撃力%',
+  '防御力%',
+  '撃破特効',
+  'EP回復効率',
+];
 
 
 export type ArtifactUsageResult = {


### PR DESCRIPTION
closed #44 

遺物/オーナメントのメインオプションごとの利用状況を表示できるようになりました

- PC表示
  - 遺物表示
      <img width="1418" alt="スクリーンショット 2025-04-06 23 56 08" src="https://github.com/user-attachments/assets/8b45175d-659d-400e-b981-65d093aceea6" />



  - オーナメント表示
     <img width="1419" alt="スクリーンショット 2025-04-06 23 56 29" src="https://github.com/user-attachments/assets/bb6a085b-a96e-4d28-bf27-22961f528c02" />



- スマホ表示
  - 遺物表示
     <img width="378" alt="スクリーンショット 2025-04-06 23 53 14" src="https://github.com/user-attachments/assets/31ba2dbf-f548-4782-9f79-8c77b481ebbf" />

    
  - オーナメント表示
     <img width="378" alt="スクリーンショット 2025-04-06 23 53 31" src="https://github.com/user-attachments/assets/c080484b-053d-4d42-a408-953d5cd40e73" />
